### PR TITLE
PR: #3 Configure Issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,12 +1,12 @@
 ---
 name: Bug Report
 about: Create a report that describes a Bug and starts an investigation into fixing this bug.
-title: "Bug: [FEATURE NAME]"
+title: "Fix: [BUG NAME]"
 labels: bug
 assignees: ''
-
+project: 'Wishing Well'
 ---
-# Bug: <bug name>
+# Bug: [bug name]
 
 ## Context
 

--- a/.github/ISSUE_TEMPLATE/configuration.md
+++ b/.github/ISSUE_TEMPLATE/configuration.md
@@ -1,13 +1,13 @@
 ---
 name: New configuration suggestion
 about: Create a suggestion to add, change or remove a configuration
-title: [CONFIGURATION NAME]
+title: "Configure: [CONFIGURATION NAME]"
 labels: 'configuration'
 assignees: ''
-
+project: 'Wishing Well'
 ---
 
-# Configuration: <Descriptive Configuration name>
+# Configuration: [Descriptive Configuration name]
 
 ## Configuration info
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,13 +1,13 @@
 ---
 name: New Documentation suggestion
-about: Create a Doccumentation issue where new documentation is added, explained or status updated
-title: [DOCUMENTATION NAME]
+about: Create a Documentation issue where new documentation is added, explained or status updated
+title: "Document: [DOCUMENTATION NAME]"
 labels: 'documentation'
 assignees: ''
-
+project: 'Wishing Well'
 ---
 
-# Documentation: <Descriptive Documentation name>
+# Documentation: [Descriptive Documentation name]
 
 ## Documentation info
 

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -1,27 +1,27 @@
 ---
 name: Improvement to a Feature
 about: Create a story to improve current behaviour
-title: [IMPROVEMENT NAME]
-labels: 'improvement'
+title: "Improve: [IMPROVEMENT NAME]"
+labels: 'enhancement'
 assignees: ''
-
+project: 'Wishing Well'
 ---
 
-# Improvement: <Epic> - <Descriptive improvement Name>
+# Improvement: [Epic] - [Descriptive improvement Name]
 
 ## User Story
 
-<Describe the user story>
+[Describe the user story]
 
 ## General Info
 
-**Impacted Users**: <Describe the impacted users with this feature>   
-**Functionality**: <Describe the functionality and what it is suposed to do and how it should be used>   
-**Impact**: <Describe the impact to the current software and code>   
+**Impacted Users**: [Describe the impacted users with this feature]   
+**Functionality**: [Describe the functionality and what it is suposed to do and how it should be used]   
+**Impact**: [Describe the impact to the current software and code]   
 **URI**:
-- <API> <Describe the endpoints being impacted>   
-- <UI> <Describe the URLs being impacted>
-**Extra**: <Describe extra information>
+- API [Describe the endpoints being impacted]   
+- UI [Describe the URLs being impacted]
+**Extra**: [Describe extra information]
 
 ## Functionality Flow
 
@@ -30,21 +30,22 @@ assignees: ''
 
 ### Adjusted behaviour
 
-1. <Happy Path>
+1. [Happy Path]
 
-- <Unhappy Path 1>
-    - <Describe the unhappy path>
+**Unhappy Path**
+- [Unhappy Path 1 - title]
+    - [Describe unhappy path flow]
 
 ## Acceptance Criteria
 
-- [ ] <UI of API> <Describe AC that impact UI or API>
-- [ ] <F> <Describe AC that impact functionality>
-- [ ] <E> <Describe AC that impact none code specific features>
+- [ ] [UI of API] [Describe AC that impact UI or API]
+- [ ] [F] [Describe AC that impact functionality]
+- [ ] [E] [Describe AC that impact none code specific features]
 
 ## Ready for Sprint
 
 - **Sketch:** [Link to sketching software or import image]()
 
-<Describe extra information to get the ticket ready for development>
+[Describe extra information to get the ticket ready for development]
 
-<Show screenshots or images to clearify what should be developed>
+[Show screenshots or images to clarify what should be developed]

--- a/.github/ISSUE_TEMPLATE/new_feature.md
+++ b/.github/ISSUE_TEMPLATE/new_feature.md
@@ -1,45 +1,51 @@
 ---
 name: New Feature Story
 about: Create a feature story as an issue for tracking new feature suggestions
-title: [FEATURE NAME]
-labels: 'feature'
+title: "Develop: [FEATURE NAME]"
+labels: 'enhancement'
 assignees: ''
-
+project: 'Wishing Well'
 ---
 
-# Feature: <Epic> - <Descriptive Feature Name>
+# Feature: [Epic] - [Descriptive Feature Name]
 
 ## User Story
 
-<Describe the user story>
+[Describe the user story]
 
 ## General Info
 
-**Impacted Users**: <Describe the impacted users with this feature>   
-**Functionality**: <Describe the functionality and what it is suposed to do and how it should be used>   
-**Impact**: <Describe the impact to the current software and code>   
+**Impacted Users**: [Describe the impacted users with this feature]   
+**Functionality**: [Describe the functionality and what it is suposed to do and how it should be used]   
+**Impact**: [Describe the impact to the current software and code]   
 **URI**:
-- <API> <Describe the endpoints being impacted>   
-- <UI> <Describe the URLs being impacted>
-**Extra**: <Describe extra information>
+- API [Describe the endpoints being impacted]
+- UI [Describe the URLs being impacted]
+  **Extra**: [Describe extra information]
 
 ## Functionality Flow
 
-1. <Happy Path>
+### Current Behaviour
 
-- <Unhappy Path 1>   
-   - <Describe the unhappy path>
+
+### Adjusted behaviour
+
+1. [Happy Path]
+
+**Unhappy Path**
+- [Unhappy Path 1 - title]
+  - [Describe unhappy path flow]
 
 ## Acceptance Criteria
 
-- [ ] <UI of API> <Describe AC that impact UI or API>
-- [ ] <F> <Describe AC that impact functionality>
-- [ ] <E> <Describe AC that impact none code specific features>
+- [ ] [UI of API] [Describe AC that impact UI or API]
+- [ ] [F] [Describe AC that impact functionality]
+- [ ] [E] [Describe AC that impact none code specific features]
 
 ## Ready for Sprint
 
 - **Sketch:** [Link to sketching software or import image]()
 
-<Describe extra information to get the ticket ready for development>
+[Describe extra information to get the ticket ready for development]
 
-<Show screenshots or images to clearify what should be developed>
+[Show screenshots or images to clarify what should be developed]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,24 +1,24 @@
 ---
 name: Standard Pull Request
-about: Create a feature story as an issue for tracking new feature suggestions
+about: Create a standard pull request
 title: "PR: #[Issue number] [Issue title]"
 labels: ''
 assignees: ''
-
+project: 'Wishing Well'
 ---
 # Pull Request: #[Issue number] [Issue title]
 
-## Describe your changes
+## Changes summary
 
-## Describe extra feedback requests if applicable
+## Required feedback
 
-## Issue ticket number and link
+- [ ] Question 1
 
 ## Checklist before requesting a review
 - [ ] I have performed a self-review of my code
 - [ ] If it is a core feature, I have added thorough tests.
 - [ ] Do we need to implement analytics?
-- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
+- [ ] Do we need to implement logging?
 
 ## Checklist for a reviewer
 - [ ] Pull the repository and branch locally and manually test the changes.


### PR DESCRIPTION
# Pull Request: #3 Configure Issue and PR templates

## Changes summary

- Issue templates
   - In the issue templates, I updated the titles so they start with their type of issue, before querying for the issue title.
   - The labels are synced with the labels on the project and repository.
   - Attempt to couple the project immediately when an issue is created
   - Removed the HTML tags and replaced them with square brackets to indicate 'text to be changed'
- PR Templates
   - Moved the only pull request template to the .gitHUb folder, out of the PULL_REQUEST_TEMPLATE folder so github recognizes it
   - Changed internal tags and titles to better represent the needed fields of a PR
   - Attempt to couple project via configuration

## Checklist before requesting a review
- [X] I have performed a self-review of my code

## Checklist for a reviewer
- [X] Does the described functionality work as proposed for both the happy and unhappy paths?